### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ Using ``pip``::
 Go to https://github.com/saxix/django-concurrency if you need to download a package or clone the repo.
 
 
-|concurrency| does not need to be added into ``INSTALLED_APPS`` unless you want to run the tests
+|concurrency| does not need to be added into ``INSTALLED_APPS`` unless you want to run the tests or use the templatetags.
 
 
 


### PR DESCRIPTION
Adjusting note regarding `INSTALLED_APPS`; **concurrency** must be added to `INSTALLED_APPS` if you want access to the templatetags.
