### PR TITLE
Failing testcase for issue #41

### DIFF
--- a/tests/migrations/0002_auto_20141009_2247.py
+++ b/tests/migrations/0002_auto_20141009_2247.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import concurrency.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name = 'TestIssue41Modal',
+            fields = [
+                ('id', models.AutoField(verbose_name = 'ID', serialize = False, auto_created = True, primary_key = True)),
+                ('version', concurrency.fields.TriggerVersionField(default = 0, help_text = 'record revision number')),
+            ],
+            options = {
+                'db_table': 'issue41',
+            },
+            bases = (models.Model,),
+        )
+    ]

--- a/tests/migrations/0003_auto_20141009_2248.py
+++ b/tests/migrations/0003_auto_20141009_2248.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0002_auto_20141009_2247'),
+    ]
+
+    operations = [
+        migrations.AlterModelTable('TestIssue41Modal', 'tests_testissue41modal'),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -133,6 +133,11 @@ class TestIssue3Model(models.Model):
     class Meta:
         app_label = 'tests'
 
+class TestIssue41Modal(models.Model):
+    version = TriggerVersionField()
+    
+    class Meta:
+        app_label = 'tests'
 
 class ListEditableConcurrentModel(SimpleConcurrentModel):
     """ Proxy model used by admin related test.


### PR DESCRIPTION
Here's a currently failing testcase for the problem I mentioned in PU #41. 
The steps I took to create it:

1. Create a new model with a `db_table` set to "issue41"
1. Create a new migration
1. Remove the `db_table` option.
1. Manually create a new migration that renames the table.

Django-concurrency fails when running the first of the two migrations because it looks for `db_table` under the current model. I had a look into it over the past hour, but I haven't been able to come up with a clean way to get it working. I think a big part of the problem is that django doesn't pass the signal handler the migration's view of the models, and instead passes the current model. I'm not sure how to get around it. My current work around in my work project is to just disable the `post_syncdb_concurrency_handler` altogether and create the triggers via the management command.