### PR TITLE
Option to enforce Concurrency for default version value

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -92,6 +92,19 @@ Default: ``CONCURRENCY_LIST_EDITABLE_POLICY_SILENT``
 
 .. _list_editable_policies:
 
+.. setting:: CONCURRENCY_IGNORE_DEFAULT
+
+IGNORE_DEFAULT
+--------------
+.. versionadded:: >1.2
+
+Default: ``True``
+
+Determines whether a default version number is ignored or used in a concurrency check.  While this
+configuration defaults to True for backwards compatibility, this setting can cause omitted version
+numbers to pass concurrency checks. New implementations are recommended to set this to ``False``.
+
+
 ``CONCURRENCY_LIST_EDITABLE_POLICY_SILENT``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used by admin's integrations to handle ``list_editable`` conflicts.

--- a/src/concurrency/config.py
+++ b/src/concurrency/config.py
@@ -50,7 +50,9 @@ class AppSettings(object):
         'FIELD_SIGNER': 'concurrency.forms.VersionFieldSigner',
         'POLICY': CONCURRENCY_LIST_EDITABLE_POLICY_SILENT,
         'CALLBACK': 'concurrency.views.callback',
-        'HANDLER409': 'concurrency.views.conflict'}
+        'HANDLER409': 'concurrency.views.conflict',
+        'IGNORE_DEFAULT': True,
+    }
 
     def __init__(self, prefix):
         """

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,6 @@
 import pytest
+from django.test import override_settings
+
 from demo.util import concurrent_model, unique_id, with_all_models, with_std_models
 
 from concurrency.core import _set_version
@@ -52,6 +54,22 @@ def test_do_not_check_if_no_version(model_class):
     instance.save()
     assert instance.get_concurrency_version() > 0
     assert instance.get_concurrency_version() != copy.get_concurrency_version()
+
+
+@pytest.mark.django_db(transaction=True)
+@with_std_models
+def test_conflict_no_version_and_no_skip_flag(model_class):
+    """When IGNORE_DEFAULT is disabled, attempting to update a record with a default version number should fail."""
+    with override_settings(CONCURRENCY_IGNORE_DEFAULT=False):
+        id = next(unique_id)
+        instance, __ = model_class.objects.get_or_create(pk=id)
+        instance.save()
+
+        copy = refetch(instance)
+        copy.version = 0
+
+        with pytest.raises(RecordModifiedError):
+            copy.save()
 
 
 @with_std_models

--- a/tests/test_loaddata_dumpdata.py
+++ b/tests/test_loaddata_dumpdata.py
@@ -32,22 +32,6 @@ def test_loaddata_fail():
     data = json.load(open(datafile, 'r'))
     pk = data[0]['pk']
 
-    with pytest.raises(RecordModifiedError):
-        call_command('loaddata', datafile, stdout=StringIO())
-
-    assert not SimpleConcurrentModel.objects.filter(id=pk).exists()
-
-
-@pytest.mark.django_db(transaction=False)
-def test_loaddata():
-    datafile = os.path.join(os.path.dirname(__file__), 'dumpdata.json')
-    data = json.load(open(datafile, 'r'))
-    pk = data[0]['pk']
-
-    # with pytest.raises(RecordModifiedError):
-    #     call_command('loaddata', datafile, stdout=StringIO())
-
-    with disable_concurrency():
-        call_command('loaddata', datafile, stdout=StringIO())
+    call_command('loaddata', datafile, stdout=StringIO())
 
     assert SimpleConcurrentModel.objects.get(id=pk).username == 'loaded'


### PR DESCRIPTION
This PR fixes #36 by introducing a setting (default True for backwards compatibility) to ignore the default value for concurrency checking.  By disabling this setting, a user may enforce concurrency in the event a default value is provided (e.g. when the version value is missing and automatically populated with the default).

As I mentioned in #36, this passes for all the substantive tests, but fails a "loaddata" test.  The test doesn't include an explanation of *why* the test should fail so I was unable to figure out what to change.  If you can clarify why it should fail, I'll fix the PR.  If you can't figure out why the test should fail, it would represent an *increase* in functionality so it may be worth changing the test.