### PR TITLE
Fix warnings on django 1.11 with Python 3.6 -Wall

### DIFF
--- a/src/concurrency/config.py
+++ b/src/concurrency/config.py
@@ -5,9 +5,9 @@ from django.test.signals import setting_changed
 from django.utils import six
 
 try:
-    from django.core.urlresolvers import get_callable
-except ImportError:
     from django.urls.utils import get_callable
+except ImportError:
+    from django.core.urlresolvers import get_callable
 
 # List Editable Policy
 # 0 do not save updated records, save others, show message to the user

--- a/src/concurrency/forms.py
+++ b/src/concurrency/forms.py
@@ -41,10 +41,12 @@ class VersionWidget(HiddenInput):
     any value, you should use this widget to display the current revision number
     """
 
-    def _format_value(self, value):
+    def format_value(self, value):
         if value:
             value = str(value)
         return value
+
+    _format_value = format_value
 
     def render(self, name, value, attrs=None):
         ret = super(VersionWidget, self).render(name, value, attrs)

--- a/src/concurrency/middleware.py
+++ b/src/concurrency/middleware.py
@@ -7,9 +7,9 @@ from concurrency.config import conf
 from concurrency.exceptions import RecordModifiedError
 
 try:
-    from django.core.urlresolvers import get_callable
-except ImportError:
     from django.urls.utils import get_callable
+except ImportError:
+    from django.core.urlresolvers import get_callable
 
 
 class ConcurrencyMiddleware(object):


### PR DESCRIPTION
- On django 1.11, django.core.urlresolvers still exists, but issues a
  warning, so import directly from the new location first
- Widget._format_value was renamed