### PR TITLE
fix plural form header

### DIFF
--- a/src/concurrency/locale/en/LC_MESSAGES/django.po
+++ b/src/concurrency/locale/en/LC_MESSAGES/django.po
@@ -15,7 +15,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: admin.py:211
 #, python-format


### PR DESCRIPTION
After installing django-concurrency the management command `compilemessages` raises an Exception `ValueError: plural forms expression could be dangerous`.

This update changes the Plural-Form Header in https://github.com/saxix/django-concurrency/blob/develop/src/concurrency/locale/en/LC_MESSAGES/django.po#L18 

