### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Links
 
 
 
-.. |wheel| image:: https://pypip.in/wheel/blackhole/badge.png
+.. |wheel| image:: https://img.shields.io/pypi/wheel/blackhole.svg
 
 _list-editable: https://django-concurrency.readthedocs.org/en/latest/admin.html#list-editable
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-concurrency))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-concurrency`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.