### PR TITLE
 Make `ConcurrencyOptions` a standard class in Python 2.7

### DIFF
--- a/src/concurrency/core.py
+++ b/src/concurrency/core.py
@@ -56,7 +56,7 @@ def _select_lock(model_instance, version_value=None):
         pass
 
 
-class ConcurrencyOptions:
+class ConcurrencyOptions(object):
     field = None
     versioned_save = False
     manually = False


### PR DESCRIPTION
Makes `django-concurrency` more interoperable on Python 2.7. Otherwise `ConcurrencyOptions` has no `MRO` attribute, which can trigger errors in sibling Django model parent classes that perform introspection (eg, `x-workflows` raises "AttributeError: class ConcurrencyOptions has no attribute '__mro__'").