### PR TITLE
replace ugettext with gettext for Django 4 preparation

### DIFF
--- a/src/concurrency/exceptions.py
+++ b/src/concurrency/exceptions.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import SuspiciousOperation, ValidationError
 from django.db import DatabaseError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class VersionChangedError(ValidationError):

--- a/src/concurrency/fields.py
+++ b/src/concurrency/fields.py
@@ -11,7 +11,7 @@ from django.db.models import signals
 from django.db.models.fields import Field
 from django.db.models.signals import class_prepared, post_migrate
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from concurrency import forms
 from concurrency.api import get_revision_of_object

--- a/src/concurrency/forms.py
+++ b/src/concurrency/forms.py
@@ -5,7 +5,7 @@ from django.core.exceptions import NON_FIELD_ERRORS, ImproperlyConfigured, Valid
 from django.core.signing import BadSignature, Signer
 from django.forms import HiddenInput, ModelForm
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from concurrency.config import conf
 from concurrency.core import _select_lock

--- a/src/concurrency/views.py
+++ b/src/concurrency/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from django.template import loader
 from django.template.base import Template
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from concurrency.compat import TemplateDoesNotExist
 from concurrency.exceptions import RecordModifiedError

--- a/tests/test_admin_edit.py
+++ b/tests/test_admin_edit.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import pytest
 from demo.base import SENTINEL, AdminTestCase

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -4,7 +4,7 @@ from django.forms.widgets import HiddenInput, TextInput
 from django.test import TestCase, override_settings
 from django.test.testcases import SimpleTestCase
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import pytest
 from demo.models import Issue3TestModel, SimpleConcurrentModel


### PR DESCRIPTION
Currently with Django3 this results in warnings for using deprecated API.