### PR TITLE
Resolves #210 for me

### DIFF
--- a/src/concurrency/triggers.py
+++ b/src/concurrency/triggers.py
@@ -142,6 +142,7 @@ class PostgreSQL(TriggerFactory):
     END;
     ' language 'plpgsql';
 
+DROP TRIGGER IF EXISTS {trigger_name} ON {opts.db_table};
 CREATE TRIGGER {trigger_name} BEFORE UPDATE
     ON {opts.db_table} FOR EACH ROW
     EXECUTE PROCEDURE func_{trigger_name}();


### PR DESCRIPTION
Adding the `DROP TRIGGER IF EXISTS {trigger_name} ON {opts.db_table};` is harmless since the next step creates it again.  Not sure why this wasn't in here to begin with.
I think it might be needed for SQLite and MySQL but I don't have them setup to test with.