### PR TITLE
Update PostgreSQL TriggerFactory for Postgres 13 support

### DIFF
--- a/src/concurrency/triggers.py
+++ b/src/concurrency/triggers.py
@@ -147,10 +147,7 @@ CREATE TRIGGER {trigger_name} BEFORE UPDATE
     EXECUTE PROCEDURE func_{trigger_name}();
     """
 
-    list_clause = "select * from pg_trigger where tgname LIKE 'concurrency_%%'; "
-
-    def get_list(self):
-        return sorted([m[1] for m in self._list()])
+    list_clause = "select tgname from pg_trigger where tgname LIKE 'concurrency_%%'; "
 
 
 class MySQL(TriggerFactory):


### PR DESCRIPTION
In Postgres 13, a new column has been added to the `pg_trigger` table, which causes the `get_list()` function to break because it relies on a specific column position.

This change fixes this by only querying the required `tgname` column, also making it able to use the default implementation of `get_list()` in the base `TriggerFactory` class.