### PR TITLE
Support postgres 13.

### DIFF
--- a/src/concurrency/triggers.py
+++ b/src/concurrency/triggers.py
@@ -147,10 +147,7 @@ CREATE TRIGGER {trigger_name} BEFORE UPDATE
     EXECUTE PROCEDURE func_{trigger_name}();
     """
 
-    list_clause = "select * from pg_trigger where tgname LIKE 'concurrency_%%'; "
-
-    def get_list(self):
-        return sorted([m[1] for m in self._list()])
+    list_clause = "select tgname from pg_trigger where tgname LIKE 'concurrency_%%'; "
 
 
 class MySQL(TriggerFactory):


### PR DESCRIPTION
Postgres 13 reorders the pg_trigger table columns, so the hard-coded column number for the lookup of the trigger name no longer works. This leads to constant warnings about triggers not existing, and migrations failing due to trying to recreate already existing triggers.

The pg_trigger table is only used to lookup the name of the triggers, so this PR switches the `select *` with a `select tgname`

```
Postgres 11      | Postgres 13
-----------------+----------------
tgrelid          | oid
tgname           | tgrelid
tgfoid           | tgparentid
tgtype           | tgname
tgenabled        | tgfoid
tgisinternal     | tgtype
tgconstrrelid    | tgenabled
tgconstrindid    | tgisinternal
tgconstraint     | tgconstrrelid
tgdeferrable     | tgconstrindid
tginitdeferred   | tgconstraint
tgnargs          | tgdeferrable
tgattr           | tginitdeferred
tgargs           | tgnargs
tgqual           | tgattr
tgoldtable       | tgargs
tgnewtable       | tgqual
                 | tgoldtable
                 | tgnewtable
```