### PR TITLE
Fields.py: Fix 'RemovedInDjango60Warning: Passing positional arguments to save() is deprecated'

### DIFF
--- a/src/concurrency/fields.py
+++ b/src/concurrency/fields.py
@@ -301,9 +301,9 @@ class TriggerVersionField(VersionField):
 
     @staticmethod
     def _wrap_save(func):
-        def inner(self, force_insert=False, force_update=False, using=None, **kwargs):
+        def inner(self, **kwargs):
             reload = kwargs.pop("refetch", False)
-            ret = func(self, force_insert, force_update, using, **kwargs)
+            ret = func(self, **kwargs)
             TriggerVersionField._increment_version_number(self)
             if reload:
                 ret = refetch(self)


### PR DESCRIPTION
Fixed it by not using any positional arguments any more.
This seems to be the only place where this happens.