### PR TITLE
fix license format as specified by PEP 639 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,10 @@ requires = [
 name = "django-concurrency"
 description = "Optimistic lock implementation for Django. Prevents users from doing concurrent editing"
 readme = "README.md"
-license.file = "LICENSE"
+license = "MIT"
+license-files = [
+  "LICENSE",
+]
 
 authors = [
   { name = "sax", email = "s.apostolico@gmail.com" },


### PR DESCRIPTION
See:

- https://peps.python.org/pep-0639/
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
- https://spdx.org/licenses/

My changes may be used under the same license as this project.